### PR TITLE
Add CI for Rust unit tests and litehouse compilation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,10 +18,12 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
+      - name: Install cargo groups
+        run: cargo install cargo-groups
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo groups test bin
 
   build:
     name: Compile Litehouse
@@ -32,7 +34,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - name: Build litehouse
         run: cargo build --release -p litehouse

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,43 @@
+name: Rust CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: cargo test --workspace
+
+  build:
+    name: Compile Litehouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Build litehouse
+        run: cargo build --release -p litehouse
+      - name: Upload litehouse binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: litehouse-binary
+          path: target/release/litehouse


### PR DESCRIPTION
Related to #6

Introduces a new CI workflow for Rust in the `litehouse` project to ensure all crates in the workspace are tested and `litehouse` compiles successfully.

- **Adds a new GitHub Actions workflow file `.github/workflows/rust.yml`** to automate Rust unit tests and compilation checks.
  - Triggers the workflow on push and pull request events to the `main` branch.
  - Defines two jobs within the workflow: one for running tests across all workspace crates (`cargo test --workspace`) and another for compiling `litehouse` (`cargo build --release -p litehouse`).
  - Utilizes `actions-rs/toolchain` to install the Rust toolchain and `actions/upload-artifact` to upload the compiled `litehouse` binary as an artifact.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arlyon/litehouse/issues/6?shareId=6c88dda3-eaad-4626-8472-e7007d4dbe7b).