### PR TITLE
Update cargo-rdme workflow to run on all commits to main

### DIFF
--- a/.github/workflows/cargo-rdme.yml
+++ b/.github/workflows/cargo-rdme.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - main
 
 jobs:
   cargo-rdme:


### PR DESCRIPTION
Updates the GitHub Actions workflow for `cargo-rdme` to also run on all commits to the main branch.
- Adds a trigger for push events to the main branch in the `.github/workflows/cargo-rdme.yml` file, ensuring that the `cargo-rdme` workflow is executed not only for pull requests but also for direct commits to the main branch.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arlyon/litehouse?shareId=29ee374f-d84f-487f-9e6b-b80c9db35103).